### PR TITLE
スクレイピングの堅牢化: 空データ対応・ログ強化・重複除去

### DIFF
--- a/.github/workflows/slot_data_analysis.yml
+++ b/.github/workflows/slot_data_analysis.yml
@@ -42,8 +42,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install playwright
-          playwright install
-          playwright install-deps
+          python -m playwright install --with-deps chromium
 
       - name: Run Playwright script
         # run: python scraper/scraping_hall_page.py
@@ -53,11 +52,15 @@ jobs:
         # run: python scraper/scraper.py
         run: python -m scraper.scraper
 
-      - name: Save scraped results
+      - name: Save scraped logs and csv
+        if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: scraped-results
-          path: data/  # フォルダ全体
+          name: scraped-logs-and-csv
+          path: |
+            data/logs
+            data/csv
+          if-no-files-found: warn
 
 
 

--- a/scraper/data_to_supabase.py
+++ b/scraper/data_to_supabase.py
@@ -136,16 +136,42 @@ def add_data_result(df: pd.DataFrame, supabase: Client) -> None:
         logger.warning("results に挿入するデータがありません。")
         return
 
+    conflict_keys = ["hall_id", "model_id", "unit_no", "date"]
+    before_dedup = len(records)
+    records_df = pd.DataFrame(records)
+    duplicate_count = records_df.duplicated(subset=conflict_keys, keep=False).sum()
+    logger.info("results upsert前の重複件数(%s): %d 件", conflict_keys, duplicate_count)
+    if duplicate_count:
+        records_df = records_df.drop_duplicates(subset=conflict_keys, keep="last")
+        logger.info("results upsert前の重複除去: %d 件 -> %d 件", before_dedup, len(records_df))
+    records = records_df.to_dict("records")
+    logger.info("results upsert対象件数: %d 件", len(records))
+
     # 3) 一括 upsert（unique(hall_id, model_id, unit_no, date) を想定）
     #    行数が多い場合はバッチに分ける
     batch_size = 1000
     inserted = 0
     for i in range(0, len(records), batch_size):
+        batch_no = i // batch_size + 1
         batch = records[i : i + batch_size]
-        supabase.table("results").upsert(
-            batch,
-            on_conflict="hall_id,model_id,unit_no,date",
-        ).execute()
+        logger.info("results upsert batch %d: %d 件", batch_no, len(batch))
+        try:
+            supabase.table("results").upsert(
+                batch,
+                on_conflict="hall_id,model_id,unit_no,date",
+            ).execute()
+        except Exception:
+            key_samples = [
+                {key: record.get(key) for key in ["hall_id", "model_id", "unit_no", "date"]}
+                for record in batch[:5]
+            ]
+            logger.exception(
+                "results upsert失敗: batch=%d, 件数=%d, key_samples=%s",
+                batch_no,
+                len(batch),
+                key_samples,
+            )
+            raise
         inserted += len(batch)
 
     logger.info(f"results upsert: {inserted} 件（新規/既存含む）")
@@ -155,10 +181,10 @@ if __name__ == "__main__":
 
     df = pd.read_csv(config.CSV_DIR / "cleaned_all_result_data.csv")
     
-    print(df.date.unique())
-    print(df.hall.unique())
-    print(df.model.unique())
-    print(df.shape[0])
+    logger.debug("date unique: %s", df.date.unique())
+    logger.debug("hall unique: %s", df.hall.unique())
+    logger.debug("model unique: %s", df.model.unique())
+    logger.debug("row count: %d", df.shape[0])
 
     supabase = get_supabase_client()
     add_model(df, supabase)

--- a/scraper/preprocess_for_db.py
+++ b/scraper/preprocess_for_db.py
@@ -84,9 +84,16 @@ def df_data_clean(df):
 
     # 予測RB回数を計算して列修正
     calc_rb_count(df)
-    
+
     # 予測メダル数を計算して列修正
     calc_medal(df)
+
+    duplicate_keys = ["pref", "hall", "model", "date", "unit_no"]
+    duplicate_count = df.duplicated(subset=duplicate_keys, keep=False).sum()
+    logger.info("clean後の重複件数(%s): %d 件", duplicate_keys, duplicate_count)
+    if duplicate_count:
+        df = df.drop_duplicates(subset=duplicate_keys, keep="last")
+        logger.info("重複除去後の件数: %d 件", len(df))
 
     df.to_csv(config.CSV_DIR / "cleaned_all_result_data.csv", index=False)
     logger.debug(df.info())
@@ -174,7 +181,7 @@ def calc_medal(df):
         (out_bb + out_rb + out_replay + out_cherry + out_grape) - in_medal
     ).round().astype(int)
     
-    print(df_specific_halls)
+    logger.debug("補正対象ホールのmedal計算結果:\n%s", df_specific_halls)
 
     df.loc[df_specific_halls.index, "medal"] = df_specific_halls["medal_calc"]
 

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -2,7 +2,6 @@ import pandas as pd
 from urllib.parse import quote, urljoin
 import os
 import time
-import os
 import yaml
 
 from config import config
@@ -40,21 +39,26 @@ def scraper_all_hall(test_mode=False, test_count=2) -> pd.DataFrame:
         logger.info("*********** テストモードで実行しています。 **********")
 
     frames: list = []
+    cols = ["pref", "hall", "model", "date", "台番", "G数", "BB", "RB", "差枚"]
     for i, h in enumerate(hall_list, start=1):
         try:
             encoded_slug = quote(h.slug)
             hall_url = urljoin(config.MAIN_URL, encoded_slug)
             logger.info("(%d/%d) 処理中: %s", i, len(hall_list), hall_url)
             df_hall = extract_result_data(hall_url, h.period)
+            logger.info("ホール取得件数: %s / %d 件", hall_url, len(df_hall))
             if not df_hall.empty:
                 frames.append(df_hall)
         except Exception as e:
             logger.exception("ホール処理でエラー: %s", e)
 
-    df_all = pd.concat(frames, ignore_index=True)
+    if frames:
+        df_all = pd.concat(frames, ignore_index=True)
+    else:
+        logger.warning("取得データが空のため、空DataFrameを出力します。")
+        df_all = pd.DataFrame(columns=cols)
 
     # 列の順番を固定（下流の処理を安定化）
-    cols = ["pref", "hall", "model", "date", "台番", "G数", "BB", "RB", "差枚"]
     for c in cols:
         if c not in df_all.columns:
             df_all[c] = pd.NA

--- a/scraper/scraping_model_page.py
+++ b/scraper/scraping_model_page.py
@@ -69,13 +69,20 @@ def extract_model_data(
         try:
             page.wait_for_selector(css, timeout=15_000)
         except PWTimeout:
-            logger.debug("テーブルが見つかりません。")
-            # return []
+            logger.warning("テーブルが見つからないためスキップします: %s", url)
+            continue
 
         rows = page.locator(css)
+        if rows.count() == 0:
+            logger.warning("テーブル行が空のためスキップします: %s", url)
+            continue
+
         # th行(header)処理
         ths = rows.nth(0).locator("th")
         header = [_norm_text(ths.nth(i).inner_text()) for i in range(ths.count())]
+        if not header:
+            logger.warning("テーブルヘッダーが空のためスキップします: %s", url)
+            continue
         logger.debug(header)
         # td(date)行処理
         table: list[list[str]] = []
@@ -88,10 +95,16 @@ def extract_model_data(
                 table.append(row)
 
         logger.info(f"{len(table)} 行の機種データを取得")
+        if not table:
+            logger.warning("テーブルデータが空のためスキップします: %s", url)
+            continue
         for t in table:
             logger.debug(t)
 
         df = pd.DataFrame(table, columns=header)
+        if "台番" not in df.columns:
+            logger.warning("台番列が見つからないためスキップします: %s", url)
+            continue
         df = df[~df["台番"].astype(str).str.contains("平均")]
         df["pref"] = pref
         df["hall"] = hall

--- a/scraper/scraping_result_data.py
+++ b/scraper/scraping_result_data.py
@@ -11,6 +11,14 @@ from scraper.scraping_hall_page import extract_date_url
 from scraper.scraping_date_page import extract_model_url
 from scraper.scraping_model_page import extract_model_data
 
+# =========================
+# 設定・ロガー
+# =========================
+filename, ext = os.path.splitext(os.path.basename(__file__))
+logger = setup_logger(filename, log_file=config.LOG_PATH)
+
+RESULT_COLUMNS = ["pref", "hall", "model", "date", "台番", "G数", "BB", "RB", "差枚"]
+MODEL_URL_COLUMNS = ["pref", "hall", "date", "date_url", "model_url"]
 
 def extract_result_data(hall_url: str, period: int = 1):
     """
@@ -24,29 +32,37 @@ def extract_result_data(hall_url: str, period: int = 1):
 
         date_urls = extract_date_url(hall_url, page, period=period)
 
+        pref = hall = "unknown"
         try:
             df_model_urls: list = []
-            columns = ["pref", "hall", "date", "date_url", "model_url"]
             for pref, hall, date, date_url in date_urls:
                 model_urls = extract_model_url(page, hall, pref, date_url, date)
                 if not model_urls:
                     continue
-                df_model_url = pd.DataFrame(model_urls, columns=columns)
+                df_model_url = pd.DataFrame(model_urls, columns=MODEL_URL_COLUMNS)
                 df_model_urls.append(df_model_url)
 
                 df_model = extract_model_data(page, model_urls)
                 if not df_model.empty:
                     df_frames.append(df_model)
 
-            df_csv = pd.concat(df_model_urls)
-            df_csv.to_csv(config.CSV_DIR / f"{pref}_{hall}_model_urls.csv", index=False)
+            if df_model_urls:
+                df_model_urls_result = pd.concat(df_model_urls, ignore_index=True)
+            else:
+                logger.warning("機種URLが取得できませんでした: %s", hall_url)
+                df_model_urls_result = pd.DataFrame(columns=MODEL_URL_COLUMNS)
+            df_model_urls_result.to_csv(config.CSV_DIR / f"{pref}_{hall}_model_urls.csv", index=False)
 
         finally:
             browser.close()
-            df_csv = pd.concat(df_frames, ignore_index=True)
-            df_csv.to_csv(config.CSV_DIR / f"{pref}_{hall}_result_data.csv", index=False)
+            if df_frames:
+                df_result = pd.concat(df_frames, ignore_index=True)
+            else:
+                logger.warning("結果データが取得できませんでした: %s", hall_url)
+                df_result = pd.DataFrame(columns=RESULT_COLUMNS)
+            df_result.to_csv(config.CSV_DIR / f"{pref}_{hall}_result_data.csv", index=False)
 
-        return df_csv
+        return df_result
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- GitHub Actions 上で一時的に取得がゼロになるケースや HTML 構造変化が発生しても処理全体が落ちないようにするための最小修正を行いました。 
- `pd.concat` の空リストエラーや Supabase への同一バッチ内重複による upsert エラーを防止することを目的としています。 
- 失敗箇所の追跡性を高めるためにログ出力を増やし、失敗時に調査できるアーティファクトを残すようにします。 

### Description
- `scraper/scraper.py`：各ホールの取得件数をログ出力するようにし、全ホールが空のときに期待列を持つ空の `DataFrame` を作成して `pd.concat` の失敗を回避しました（列順固定と CSV 出力は維持）。
- `scraper/scraping_result_data.py`：`df_model_urls` や `df_frames` が空のときに warning を出し、期待列を持つ空 `DataFrame`（`df_result`）を返すように変更しました。
- `scraper/scraping_model_page.py`：テーブル未検出・行なし・ヘッダーなし・`台番` 列なしの各ケースで URL を含む warning を出し、該当機種ページを `continue` でスキップするようにしました。 
- `scraper/preprocess_for_db.py`：`calc_*` 後に `["pref","hall","model","date","unit_no"]` をキーとして重複件数をログ出力し、重複がある場合は `drop_duplicates(..., keep="last")` で除去するようにしました。またデバッグ `print` を `logger.debug` に置換しました。 
- `scraper/data_to_supabase.py`：`results` 用レコード作成後に `["hall_id","model_id","unit_no","date"]` で同一バッチ内の重複を除去してから upsert するようにし、重複件数・upsert 対象件数・batchごとの件数をログ出力し、upsert 失敗時は batch 番号・件数・先頭数件のキー情報をログ出力してから例外を再送出するようにしました（既存の `on_conflict="hall_id,model_id,unit_no,date"` は変更していません）。
- `.github/workflows/slot_data_analysis.yml`：Playwright のブラウザを確実に入れるために `python -m playwright install --with-deps chromium` を使用するように変更し、失敗時調査用に `data/logs` と `data/csv` をアーティファクトとして常にアップロードする設定（`if: always()` と `if-no-files-found: warn`）を追加しました。 

### Testing
- 実行したコマンドは `python -m compileall scraper` で、スクレイパー関連モジュールのコンパイルに成功しました。 
- 変更は最小限に留めて既存の CSV 出力先・列名・Supabase の `on_conflict`（`hall_id,model_id,unit_no,date`）を維持しています。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b53783a2c83239211c2d702632132)