### PR TITLE
GitHub Actions の手動再取得入力と scraper の日付上書き対応

### DIFF
--- a/.github/workflows/slot_data_analysis.yml
+++ b/.github/workflows/slot_data_analysis.yml
@@ -20,6 +20,27 @@ on:
 
   # 手動実行
   workflow_dispatch:
+    inputs:
+      target_dates:
+        description: "再取得する日付。例: 2026-07-06 または 2026-07-06,2026-07-07"
+        required: false
+        default: ""
+      force_rescrape:
+        description: "取得済みでも再取得する"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+      disable_pre_skip:
+        description: "事前スキップを無効にする"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
 
 env:
   SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
@@ -71,6 +92,9 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           JST_DATE: ${{ env.JST_DATE }}
           JST_HOUR: ${{ env.JST_HOUR }}
+          TARGET_DATES: ${{ github.event.inputs.target_dates }}
+          FORCE_RESCRAPE: ${{ github.event.inputs.force_rescrape }}
+          DISABLE_PRE_SKIP: ${{ github.event.inputs.disable_pre_skip }}
 
       - name: Save scraped logs and csv
         if: always()

--- a/scraper/scraper.py
+++ b/scraper/scraper.py
@@ -1,6 +1,8 @@
 import pandas as pd
 from urllib.parse import quote, urljoin
 import os
+import datetime as dt
+import re
 import time
 import yaml
 from playwright.sync_api import sync_playwright
@@ -18,6 +20,35 @@ from scraper.supabase_lookup import has_enough_results
 # =========================
 filename, ext = os.path.splitext(os.path.basename(__file__))
 logger = setup_logger(filename, log_file=config.LOG_PATH)
+
+
+def _parse_bool_env(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() == "true"
+
+
+def _load_target_dates_from_env() -> set[str] | None:
+    raw_target_dates = os.getenv("TARGET_DATES", "").strip()
+    if not raw_target_dates:
+        return None
+
+    target_dates: set[str] = set()
+    for raw_date in raw_target_dates.split(","):
+        target_date = raw_date.strip()
+        if not target_date:
+            continue
+        if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", target_date):
+            raise ValueError(f"TARGET_DATES は YYYY-MM-DD のカンマ区切りで指定してください: {target_date}")
+        try:
+            dt.date.fromisoformat(target_date)
+        except ValueError as exc:
+            raise ValueError(f"TARGET_DATES は YYYY-MM-DD のカンマ区切りで指定してください: {target_date}") from exc
+        target_dates.add(target_date)
+
+    if not target_dates:
+        raise ValueError("TARGET_DATES に有効な日付が指定されていません。")
+
+    logger.info("手動指定日付: target_dates=%s", ",".join(sorted(target_dates)))
+    return target_dates
 
 
 # =========================
@@ -80,6 +111,13 @@ def scraper_all_hall(
     start = time.perf_counter()
     hall_list = _load_hall_list(test_mode=test_mode, test_count=test_count)
     supabase = data_to_supabase.get_supabase_client() if upsert_each_date else None
+    target_dates = _load_target_dates_from_env()
+    force_rescrape = _parse_bool_env("FORCE_RESCRAPE")
+    disable_pre_skip = _parse_bool_env("DISABLE_PRE_SKIP")
+    if force_rescrape:
+        logger.info("force_rescrape=true のため取得済みでも再取得します")
+    if disable_pre_skip:
+        logger.info("disable_pre_skip=true のため事前スキップを無効化します")
 
     jst_date = os.getenv("JST_DATE")
     jst_hour = os.getenv("JST_HOUR")
@@ -107,7 +145,7 @@ def scraper_all_hall(
                 def should_scrape(pref: str, hall: str, date: str) -> bool:
                     nonlocal target_count, skipped_count, scrape_target_count
                     target_count += 1
-                    if supabase is None:
+                    if supabase is None or force_rescrape or disable_pre_skip:
                         scrape_target_count += 1
                         logger.info("新規取得対象: hall=%s, date=%s", hall, date)
                         return True
@@ -137,6 +175,7 @@ def scraper_all_hall(
                         hall_url,
                         h.period,
                         date_filter=should_scrape,
+                        target_dates=target_dates,
                     )
                 except Exception as e:
                     logger.exception("ホール処理でエラー: %s", e)

--- a/scraper/scraping_hall_page.py
+++ b/scraper/scraping_hall_page.py
@@ -19,9 +19,9 @@ logger = setup_logger(filename, log_file=config.LOG_PATH)
 # =========================
 # ページ操作
 # =========================
-def extract_date_url(hall_url, page, period) -> list[tuple[str, str, str, str]]:
+def extract_date_url(hall_url, page, period, target_dates: set[str] | None = None) -> list[tuple[str, str, str, str]]:
     """
-    ホールのメインページから、直近 period 件の日付リンクを取得
+    ホールのメインページから、直近 period 件または指定日付の日付リンクを取得
     returns: List[(prefecture, hall, date(YYYY-MM-DD), date_url)]
     """
 
@@ -48,7 +48,7 @@ def extract_date_url(hall_url, page, period) -> list[tuple[str, str, str, str]]:
     links = page.locator(css)
     count = links.count()
     logger.debug(f"link取得数: {count}")
-    take = min(period, count)
+    take = count if target_dates else min(period, count)
     logger.debug(f"take: {take}")
 
     date_urls: list[tuple[str, str, str, str]] = []
@@ -68,6 +68,9 @@ def extract_date_url(hall_url, page, period) -> list[tuple[str, str, str, str]]:
             date_iso = dt.date(int(y), int(mth), int(d)).strftime("%Y-%m-%d")
         except ValueError:
             logger.warning("日付に変換できません: %s", date_text)
+            continue
+
+        if target_dates is not None and date_iso not in target_dates:
             continue
 
         date_urls.append((pref, hall, date_iso, href))

--- a/scraper/scraping_result_data.py
+++ b/scraper/scraping_result_data.py
@@ -25,12 +25,13 @@ def extract_result_data_by_dates(
     hall_url: str,
     period: int = 1,
     date_filter=None,
+    target_dates: set[str] | None = None,
 ) -> list[tuple[str, str, str, pd.DataFrame, int]]:
     """ホール×日付単位で結果データを取得する。
 
     returns: List[(pref, hall, date, df_result, model_count)]
     """
-    date_urls = extract_date_url(hall_url, page, period=period)
+    date_urls = extract_date_url(hall_url, page, period=period, target_dates=target_dates)
     results: list[tuple[str, str, str, pd.DataFrame, int]] = []
 
     for pref, hall, date, date_url in date_urls:


### PR DESCRIPTION
### Motivation
- 手動実行で任意の日付（単日/複数日）を再取得できるようにし、取得済みでも再取得する `force_rescrape` と DB 事前スキップを無効化する `disable_pre_skip` を追加するため。\n- 既存の自動スケジュール実行や `halls.yaml` の period ベースの挙動を壊さないことを優先するため。\n
### Description
- 変更ファイル: `.github/workflows/slot_data_analysis.yml`, `scraper/scraper.py`, `scraper/scraping_hall_page.py`, `scraper/scraping_result_data.py`.\n- GitHub Actions の `workflow_dispatch` に `target_dates`, `force_rescrape`, `disable_pre_skip` の `inputs` を追加し、ジョブ実行時にそれぞれ `TARGET_DATES`, `FORCE_RESCRAPE`, `DISABLE_PRE_SKIP` 環境変数として Python 実行に渡すようにした。\n- `scraper/scraper.py` に `TARGET_DATES` をカンマ区切りで読み取り `YYYY-MM-DD` を厳密に検証する `_load_target_dates_from_env()` と真偽値パースの `_parse_bool_env()` を追加し、手動指定日付・フラグに応じたログ出力を行うようにした。\n- `force_rescrape=true` または `disable_pre_skip=true` の場合は既存の事前スキップ判定（`has_enough_results`）を迂回して取得対象とする分岐を追加したが、DB 削除は行わず既存の upsert 経路のみを維持している。\n- `target_dates` 指定時は `scraping_hall_page.extract_date_url` に `target_dates` を渡し、ページ上の全リンクから指定日を抽出するようにし、未指定時は従来通り `period` 件のみを対象にする挙動を維持した。\n- `scraping_result_data.extract_result_data_by_dates` のシグネチャを拡張して `target_dates` を中継する最小改修に留め、既存のモデル取得・結果取得・CSV 出力・upsert のフローは変更していない。\n- 追加ログ例: `[INFO] 手動指定日付: target_dates=2026-07-06,2026-07-07`、`[INFO] force_rescrape=true のため取得済みでも再取得します`、`[INFO] disable_pre_skip=true のため事前スキップを無効化します`。\n
### Testing
- 型チェック/構文チェック: `python -m py_compile scraper/scraper.py scraper/scraping_result_data.py scraper/scraping_hall_page.py` を実行し成功。\n- 日付パース検証: 簡易テストで `TARGET_DATES='2026-07-06,2026-07-07'` が正しくパースされること、および `TARGET_DATES='2026-7-6'` のような不正形式で `ValueError` が出ることを確認した（スクリプト内で実行）。\n- Git 検査: `git diff --check` にて差分警告はなし。\n- 注意: フルエンドツーエンド（実際の Playwright によるサイト取得・Supabase への upsert）は CI 上の外部サービス依存のため今回ローカルでの自動実行は行っておらず、既存の upsert / マテビュー更新ロジックには変更を加えていないため本番ワークフロー上での挙動は従来通りです。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54290dc2bc832381ecccd6e4173392)